### PR TITLE
Build on GCC 10

### DIFF
--- a/src/output-plugins/log.h
+++ b/src/output-plugins/log.h
@@ -19,8 +19,8 @@ typedef struct _output_plugin {
    void *data;                                                 /* anything else */
 } output_plugin;
 
-enum { LOG_STDOUT, LOG_FILE, LOG_FIFO, LOG_UNIFIED, LOG_SGUIL, LOG_RINGBUFFER, LOG_MAX } log_types;
-enum { VERBOSE = 0x01, FLAGS } log_flags;
+extern enum { LOG_STDOUT, LOG_FILE, LOG_FIFO, LOG_UNIFIED, LOG_SGUIL, LOG_RINGBUFFER, LOG_MAX } log_types;
+extern enum { VERBOSE = 0x01, FLAGS } log_flags;
 
 void log_asset_arp (asset *main);
 void log_asset_os (asset *main, os_asset *os, connection *cxt);

--- a/src/servicefp/servicefp.c
+++ b/src/servicefp/servicefp.c
@@ -47,7 +47,7 @@
 
 extern globalconfig config;
 
-servicelist *services[MAX_PORTS];
+extern servicelist *services[MAX_PORTS];
 
 /* ----------------------------------------------------------
  * FUNCTION     : init_identification


### PR DESCRIPTION
GCC 10 defaults to -fno-common, which no longer ignores a missing
"extern" when declaring a global variable in a header file.

This patch adds "extern" to global variables so prads builds with GCC 10 defaults.