### PR TITLE
Add support for loongarch

### DIFF
--- a/src/dump_dns.c
+++ b/src/dump_dns.c
@@ -98,7 +98,7 @@ void printchars(char buf[NS_MAXDNAME], u_char * cdata, u_int16_t dlen);
 	(cp) += INT32SZ; \
 } while (0)
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__loongarch__)
 const char *_res_opcodes[] = {
         "QUERY",
         "IQUERY",


### PR DESCRIPTION
Fix a compilation error in loongarch, details of the error are as follows:[https://buildd.debian.org/status/fetch.php?pkg=prads&arch=loong64&ver=0.3.3-7&stamp=1709416912&raw=0](url)